### PR TITLE
Parse rows as maps

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/prestodb/presto-go-client
+module github.com/joshuawright11/presto-go-client
 
 go 1.14
 

--- a/presto/presto.go
+++ b/presto/presto.go
@@ -886,7 +886,7 @@ func (c *typeConverter) ConvertValue(v interface{}) (driver.Value, error) {
 				converter := newTypeConverter(item.typeName)
 				value, err := converter.ConvertValue(values[pos])
 				if err != nil {
-					fmt.Printf("Error converting value of %s: %s\n", item.name, err.Error())
+					return nil, err
 				} else {
 					m[item.name] = value
 					fmt.Printf("type passed %s\n", item.typeName)

--- a/presto/presto.go
+++ b/presto/presto.go
@@ -868,32 +868,29 @@ func (c *typeConverter) ConvertValue(v interface{}) (driver.Value, error) {
 			return nil, err
 		}
 		return v, nil
-	default:
-		if strings.HasPrefix(c.typeName, "row(") {
-			values, ok := v.([]interface{})
-			if !ok {
-				return nil, fmt.Errorf("can't convert type to row: %q", c.typeName)
-			}
-
-			rowItems := parseRowItems(c.typeName)
-			if len(rowItems) != len(values) {
-				return nil, fmt.Errorf("there should be as many types as there are values")
-			}
-
-			m := map[string]driver.Value{}
-
-			for pos, item := range rowItems {
-				converter := newTypeConverter(item.typeName)
-				value, err := converter.ConvertValue(values[pos])
-				if err != nil {
-					return nil, err
-				} else {
-					m[item.name] = value
-					fmt.Printf("type passed %s\n", item.typeName)
-				}
-			}
-			return m, nil
+	case "row":
+		values, ok := v.([]interface{})
+		if !ok {
+			return nil, fmt.Errorf("can't convert type to row: %q", c.typeName)
 		}
+
+		rowItems := parseRowItems(c.typeName)
+		if len(rowItems) != len(values) {
+			return nil, fmt.Errorf("there should be as many types as there are values")
+		}
+
+		m := map[string]driver.Value{}
+
+		for pos, item := range rowItems {
+			converter := newTypeConverter(item.typeName)
+			value, err := converter.ConvertValue(values[pos])
+			if err != nil {
+				return nil, err
+			}
+			m[item.name] = value
+		}
+		return m, nil
+	default:
 		return nil, fmt.Errorf("type not supported: %q", c.typeName)
 	}
 }


### PR DESCRIPTION
If the presto column is a `row(...)` (aka `struct`) this parses it into a `map[string]driver.Value` where `string` is the key of the struct field & `driver.Value` is the presto value converted to go.

e.g. consider table `my_table` with `string_field: varchar` `row_field: row(some_string: varchar, some_int: bigint)`

```go
rows, _ = prestodb.Query("SELECT string_field row_field FROM my_table")
for rows.Next() {
    var s string
    var m map[string]driver.Value
    err := rows.Scan(&s, &m)
    nestedString := m["some_string"].(string)
}
```

